### PR TITLE
set ruby and extension gem versions, bump to version 0.2.0-pre1

### DIFF
--- a/lib/urbanopt/core/version.rb
+++ b/lib/urbanopt/core/version.rb
@@ -30,6 +30,6 @@
 
 module URBANopt
   module Core
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.2.0.pre1'.freeze
   end
 end

--- a/urbanopt-core-gem.gemspec
+++ b/urbanopt-core-gem.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '= 2.2.4'
+  spec.required_ruby_version = '~> 2.2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '12.3.1'

--- a/urbanopt-core-gem.gemspec
+++ b/urbanopt-core-gem.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.2.4'
+  spec.required_ruby_version = '= 2.2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '12.3.1'

--- a/urbanopt-core-gem.gemspec
+++ b/urbanopt-core-gem.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'urbanopt-core'
   spec.version       = URBANopt::Core::VERSION
   spec.authors       = ['Dan Macumber', 'Nicholas Long']
-  spec.email         = ['daniel.macumber@nrel.gov', 'nicholas.long@nrel.gov']
+  spec.email         = ['nicholas.long@nrel.gov']
   spec.summary       = 'URBANopt core library and measures'
   spec.description   = 'URBANopt core library and measures'
   spec.homepage      = 'https://github.com/urbanopt'
@@ -20,10 +20,11 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '~> 2.2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '12.3.1'
   spec.add_development_dependency 'rspec', '3.7.0'
 
-  spec.add_dependency 'openstudio-extension', '~> 0.1.3'
+  spec.add_dependency 'openstudio-extension', '~> 0.1.6'
 end


### PR DESCRIPTION
Addresses #9 

- Declare Ruby version
- Remove Dan's email from author's list
- Update openstudio-extension-gem dependency to 0.1.6

What is the correct syntax to specify an exact ruby version?