### PR TITLE
Set up custom config file for automatic Github changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - DO NOT MERGE
+      - invalid
+      - dependencies
+      - tests
+    authors:
+      - octocat
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+        - Feature
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: docker://nrel/openstudio:3.6.1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update gems
         run: bundle update
       - name: Run Rspec

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Gemfile.lock
 
 # Ignore IDE files
 /.idea
+
+# Mac stuff
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@ Gemfile.lock
 
 # Ignore IDE files
 /.idea
-
-# Mac stuff
-*.DS_Store


### PR DESCRIPTION
- Use our UO standard config file for automatic github changelogs

### To use:
1. Draft a release in github
1. Click the `Generate changelog` button
    1. If we want to maintain a separate changelog file, copy/paste this output into the file, commit it, and ensure it is included in what will be released.
    1. Otherwise, carry on.