### PR TITLE
Upgrade to OpenStudio 3.8 & Ruby 3.2

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Update gems
-        run: bundle update
+        run: bundle install
       - name: Run Rspec
         run: bundle exec rspec
       # coveralls action docs: https://github.com/marketplace/actions/coveralls-github-action

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -2,6 +2,7 @@ name: Core-gem CI
 
 on:
   # push:
+  workflow_dispatch:
   schedule:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5 am UTC (11pm MDT the day before) every weekday night in MDT
@@ -18,7 +19,7 @@ jobs:
   weeknight-tests:
     runs-on: ubuntu-latest
     container:
-      image: docker://nrel/openstudio:3.7.0
+      image: docker://nrel/openstudio:3.8.0
     steps:
       - uses: actions/checkout@v4
       - name: Update gems

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Gemfile.lock
 /gems
 /_yardoc/
 /coverage/
+.coverage
 /doc/
 /pkg/
 /spec/reports/

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,10 @@ gemspec
 # checkout the latest version (develop) from github.
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
+gem 'regexp_parser', '2.9.0'
+# 2.9.1 breaks test_with_openstudio, for more information: https://github.com/NREL/OpenStudio/issues/5203
 # pin this dependency to avoid unicode_normalize error
-# gem 'addressable', '2.8.1'
+gem 'addressable', '2.8.1' # openstudio:test_with_openstudio
 # pin this dependency to avoid using racc dependency (which has native extensions)
 # gem 'parser', '3.2.2.2'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ gemspec
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
 # pin this dependency to avoid unicode_normalize error
-gem 'addressable', '2.8.1'
+# gem 'addressable', '2.8.1'
 # pin this dependency to avoid using racc dependency (which has native extensions)
-gem 'parser', '3.2.2.2'
+# gem 'parser', '3.2.2.2'
 
 # if allow_local && File.exist?('../OpenStudio-extension-gem')
 #   gem 'openstudio-extension', path: '../OpenStudio-extension-gem'

--- a/lib/urbanopt/core/version.rb
+++ b/lib/urbanopt/core/version.rb
@@ -5,6 +5,6 @@
 
 module URBANopt
   module Core
-    VERSION = '0.11.0'.freeze
+    VERSION = '0.12.0'.freeze
   end
 end

--- a/urbanopt-core-gem.gemspec
+++ b/urbanopt-core-gem.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 3.2'
+  # We support exactly Ruby v3.2.2 because os-extension requires bundler==2.4.10 and that requires Ruby 3.2.2: https://stdgems.org/bundler/
+  # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
+  spec.required_ruby_version = '3.2.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.4.10'
-  spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'

--- a/urbanopt-core-gem.gemspec
+++ b/urbanopt-core-gem.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'
 
-  spec.add_dependency 'openstudio-extension', '~> 0.8.0'
+  spec.add_dependency 'openstudio-extension', '~> 0.8.1'
 end

--- a/urbanopt-core-gem.gemspec
+++ b/urbanopt-core-gem.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '3.2.2'
 
   spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'rubocop', '1.50'
   spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'
 

--- a/urbanopt-core-gem.gemspec
+++ b/urbanopt-core-gem.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.7.0'
+  spec.required_ruby_version = '~> 3.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'simplecov', '~> 0.18.2'
-  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
+  spec.add_development_dependency 'bundler', '~> 2.4.10'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'simplecov', '0.22.0'
+  spec.add_development_dependency 'simplecov-lcov', '0.8.0'
 
-  spec.add_dependency 'openstudio-extension', '~> 0.7.1'
+  spec.add_dependency 'openstudio-extension', '~> 0.8.0'
 end


### PR DESCRIPTION
The current version of OpenStudio, [v3.8](https://github.com/NREL/OpenStudio/releases) includes a major breaking change to move from Ruby 2.7.2 to Ruby 3.2.2.